### PR TITLE
Pause / Stop playback & reset counter for Movie

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,10 +10,13 @@ JELLYFIN_API_TOKEN = os.getenv("JELLYFIN_API_TOKEN")
 EPISODE_START_INTERVAL = float(os.getenv("EPISODE_START_INTERVAL"))
 EPISODE_COUNT = float(os.getenv("EPISODE_COUNT"))
 JELLYFIN_MESSAGE = os.getenv("JELLYFIN_MESSAGE")
+JELLYFIN_STOPPLAYBACK = os.getenv("JELLYFIN_STOPPLAYBACK")
 
 if JELLYFIN_MESSAGE is None:
-        JELLYFIN_MESSAGE = "Stopping Playback"
-
+        JELLYFIN_MESSAGE = "Are you still watching?"
+if JELLYFIN_STOPPLAYBACK is None:
+       JELLYFIN_STOPPLAYBACK = "STOP"
+        
 app = Flask(__name__)
 
 # In-memory tracking
@@ -50,7 +53,7 @@ def webhook():
         }
 
         # Check if this is a "PlaybackStart" event for an episode
-        if notification_type == "PlaybackStart" and item_type == "Episode":
+        if notification_type == "PlaybackStart": # and item_type == "Episode":
             key = f"{user_id}-{device_id}"
 
             print(f"ℹ️ PlaybackStart event received from user: {session.get('NotificationUsername', 'Unknown')}\n🌐 Device Address: {session.get('RemoteEndPoint', 'Unknown')}")
@@ -64,12 +67,18 @@ def webhook():
             tracker = playback_tracker[key]
             time_since_last_play = time.time() - tracker["last_play_time"]
 
+            # Reset playback counter if Movie starts
+            if item_type == "Movie":
+                tracker["count"] = 0
+                print(f"Movie started reset count for user: {session.get('NotificationUsername', 'Unknown')}")
+                    
             # Reset the count if playback events are far apart (e.g., > 1 hour)
             if time_since_last_play > (60 * EPISODE_START_INTERVAL):
                 tracker["count"] = 0
 
             # Increment the playback count
-            tracker["count"] += 1
+            if item_type == "Episode":
+                tracker["count"] += 1
             tracker["last_play_time"] = time.time()
 
             print(f"ℹ️ {session.get('NotificationUsername', 'Unknown')} has played {tracker['count']} episodes in a row.")
@@ -102,10 +111,12 @@ def stop_playback(session):
     try:
         # Construct the URL to stop playback
         stop_url = f"{JELLYFIN_API_URL}/Sessions/{session_id}/Playing/Stop?ApiKey={JELLYFIN_API_TOKEN}"
+        # Construct the URL to pause playback
+        pause_url = f"{JELLYFIN_API_URL}/Sessions/{session_id}/Playing/Pause/?ApiKey={JELLYFIN_API_TOKEN}"
         
         # Send the request to stop playback
         req = urllib.request.urlopen(urllib.request.Request(stop_url, method="POST"))
-        print(f"👤 {session.get('NotificationUsername', 'Unknown')} has played {int(EPISODE_COUNT)} episodes in a row.\n❗️ ⏹️ Stopping Playback ❗️\n🌐 Device Address: {session.get('RemoteEndPoint', 'Unknown')}")
+        print(f"👤 {session.get('NotificationUsername', 'Unknown')} has played {int(EPISODE_COUNT)} episodes in a row.\n❗️ ⏹️ {JELLYFIN_STOPPLAYBACK} Playback ❗️\n🌐 Device Address: {session.get('RemoteEndPoint', 'Unknown')}")
         print()
 
         # Wait for 2 seconds before sending the next command
@@ -115,7 +126,8 @@ def stop_playback(session):
         go_home_url = f"{JELLYFIN_API_URL}/Sessions/{session_id}/Command/GoHome?ApiKey={JELLYFIN_API_TOKEN}"
         
         # Send the request to navigate back to the home screen
-        req = urllib.request.urlopen(urllib.request.Request(go_home_url, method="POST"))
+        if JELLYFIN_STOPPLAYBACK == "STOP":
+            req = urllib.request.urlopen(urllib.request.Request(go_home_url, method="POST"))
 
         return True
     except Exception as e:


### PR DESCRIPTION
Adding JELLYFIN_STOPPLAYBACK to the enviroment to either STOP or PAUSE the playback depending on the value of the paramater (Options PAUSE / STOP) 

Counter will also reset to 0 when user start a movie.